### PR TITLE
Ensure invite email addresses end with “.gov.uk” not “gov.uk”

### DIFF
--- a/slack_bot.js
+++ b/slack_bot.js
@@ -326,7 +326,7 @@ controller.hears(["^set role for <@(.*)> to (.*)"], 'direct_mention,direct_messa
 });
 
 function hasApprovedEmailDomain(email) {
-  if (email.match(".*gov\.uk$")) {
+  if (email.match(".*\.gov\.uk$")) {
     return true;
   }
   return false;


### PR DESCRIPTION
So bob@idontworkforthegov.uk can’t receive an invitation