### PR TITLE
Updated welcome message to link to display name edit field

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -364,8 +364,8 @@ controller.on('team_join', function(bot, message) {
             convo.say(
                 // This is the message new joiners will get as a DM from the bot
                 `Hello ${message.user.name},\n` +
-                'Please add your organisation name to the end of your slack handle so that other users can easily see where you work. For example, `username_hmrc` or `username_dwp`.\n' +
-                `You can change it here: https://${slackDomain}.slack.com/account/settings#username\n` +
+                'Please add your organisation name to the end of your slack handle so that other users can easily see where you work. For example, `displayname_hmrc` or `displayname_dwp`.\n' +
+                `You can change it here: https://${slackDomain}.slack.com/account/profile#display_name_profile_field\n` +
                 'Please also update your profile to describe your role in the organisation, for example "Delivery manager at GDS".\n' +
                 `You can edit your profile here: https://${slackDomain}.slack.com/account/profile\n`
             );


### PR DESCRIPTION
This PR updates the bot to ask the user to change the `display_name` field rather than `username` to include their organisation's initials. This brings behaviour in line with Slack's name handling changes.

As noted by @edwardhorsford in issue #6.