### PR TITLE
Allow CQC to join Slack

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -3,7 +3,8 @@
 var approvedDomains = [
   /.*@(.*\.)?gov.uk$/,
   /.*@(.*\.)?naturalengland.org.uk$/,
-  /.*@(.*\.)?bankofengland.co.uk$/
+  /.*@(.*\.)?bankofengland.co.uk$/,
+  /.*@(.*\.)?cqc.org.uk$/
 ];
 
 function hasApprovedEmail(email) {


### PR DESCRIPTION
The [Care Quality Commission](http://www.cqc.org.uk) are the independent regulator for health and social care in England, and are working with GDS, Department of Health, and other central government agencies, so it'd be useful for them to be able to access the cross-government Slack.