### PR TITLE
Add os.uk addresses for Ordnance Survey

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -6,7 +6,8 @@ var approvedDomains = [
   /.*@(.*\.)?bankofengland.co.uk$/,
   /.*@(.*\.)?cqc.org.uk$/,
   /.*@(.*\.)?nhs.net$/,
-  /.*@(.*\.)?sepa.org.uk$/
+  /.*@(.*\.)?sepa.org.uk$/,
+  /.*@(.*\.)?os.uk$/
 ];
 
 function hasApprovedEmail(email) {


### PR DESCRIPTION
Allow people with os.uk addresses. The Ordnance Survey is a public corporation of the Department for Business, Energy & Industrial Strategy.