### PR TITLE
Configure the database correctly in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 services:
 - docker
+- postgresql
+before_script:
+- psql -c 'create database xgovslackbot;' -U postgres
+- psql -c "create user xgovslackbot with password 'xgovslackbot';" -U postgres
 script:
-- docker build -t xgovslackbot .
+- docker build --build-arg BOTKIT_STORAGE_POSTGRES_HOST="$(/sbin/ip route|awk '/default/ { print $3 }')" -t xgovslackbot .
 deploy:
   provider: cloudfoundry
   username: xgovslack-ci@googlegroups.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 from node:8
 label maintainer="michael@brunton-spall.co.uk"
 label uk.co.brunton-spall.version="0.0.1-beta"
+ARG BOTKIT_STORAGE_POSTGRES_HOST=localhost
 ENV token=xoxb-token apitoken=xoxp-apitoken slackdomain=mbs-bot-test.slack.com
 copy . /usr/src/xgovslackbot
 workdir /usr/src/xgovslackbot
 run npm install --dev
-run npm test .
+run BOTKIT_STORAGE_POSTGRES_HOST=$BOTKIT_STORAGE_POSTGRES_HOST npm test .

--- a/app/pg_storage.js
+++ b/app/pg_storage.js
@@ -8,14 +8,14 @@ var pg = require('pg');
 
 module.exports = function(srcConfig) {
   config = {
-    user: srcConfig.user || process.env.BOTKIT_STORAGE_POSTGRES_USER || 'botkit',
-    database: srcConfig.database || process.env.BOTKIT_STORAGE_POSTGRES_DATABASE || 'botkit',
-    password: srcConfig.password || process.env.BOTKIT_STORAGE_POSTGRES_PASSWORD || 'botkit',
-    host: srcConfig.host || process.env.BOTKIT_STORAGE_POSTGRES_HOST || 'localhost',
-    port: srcConfig.port || process.env.BOTKIT_STORAGE_POSTGRES_PORT || '5432',
-    max: srcConfig.maxClients || process.env.BOTKIT_STORAGE_POSTGRES_MAX_CLIENTS || '10',
-    idleTimeoutMillis: srcConfig.idleTimeoutMillis || process.env.BOTKIT_STORAGE_POSTGRES_IDLE_TIMEOUT_MILLIS || '30000',
-    ssl: srcConfig.ssl || process.env.BOTKIT_STORAGE_POSTGRES_SSL || false,
+    user: process.env.BOTKIT_STORAGE_POSTGRES_USER || srcConfig.user || 'botkit',
+    database: process.env.BOTKIT_STORAGE_POSTGRES_DATABASE || srcConfig.database || 'botkit',
+    password: process.env.BOTKIT_STORAGE_POSTGRES_PASSWORD || srcConfig.password || 'botkit',
+    host: process.env.BOTKIT_STORAGE_POSTGRES_HOST || srcConfig.host || 'localhost',
+    port: process.env.BOTKIT_STORAGE_POSTGRES_PORT || srcConfig.port || '5432',
+    max: process.env.BOTKIT_STORAGE_POSTGRES_MAX_CLIENTS || srcConfig.maxClients || '10',
+    idleTimeoutMillis: process.env.BOTKIT_STORAGE_POSTGRES_IDLE_TIMEOUT_MILLIS || srcConfig.idleTimeoutMillis || '30000',
+    ssl: process.env.BOTKIT_STORAGE_POSTGRES_SSL || srcConfig.ssl || false,
   };
 
   function initClient(config) {


### PR DESCRIPTION
Currently, the database isn't required for running tests, but it will be for future work (eg, PR #36).

Currently, when the tests are run, the code attempts to make an asynchronous connection to the database.  If this connection attempt fails, a message is logged, but since no tests use the database nothing further happens.  The message can be seen in the logs for past successful travis runs - eg https://travis-ci.org/bruntonspall/xgovslackbot/builds/327247682#L499

This patch instead sets the database up correctly for use in travis environments.  This requires:
 - telling travis to provide a postgres database
 - creating the xgovslackbot database and users in postgres
 - updating the docker configuration so that the BOTKIT_STORAGE_POSTGRES_HOST environment variable can be passed into the container.
 - using this variable to tell the tests how to connect to the travis postgres database (which is running in the travis host, not within the container).
 - updating pg_storage so that if the BOTKIT_* environment variables are set, they override the configuration from source files.