### PR TITLE
Add kew.org to domain whitelist

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -23,7 +23,8 @@ var approvedDomains = [
   'parliament.uk',
   'sepa.org.uk',
   'slc.co.uk',
-  'stfc.ac.uk'
+  'stfc.ac.uk',
+  'kew.org'
 ]
 
 function hasApprovedEmail(email) {


### PR DESCRIPTION
I'd like to add one or two colleagues who currently work at the publicly-funded, Defra-associated Kew Gardens.