### PR TITLE
Only try and claim the lock once per process

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -24,6 +24,7 @@ if (!process.env.slackDomain) {
 var secretWord = process.env.secretWord || "abracadabra";
 
 var instanceId = uuidv4();
+var started_claim = false;
 
 var appEnv = cfenv.getAppEnv();
 if (appEnv.isLocal) {
@@ -134,6 +135,8 @@ function reportInBotsChannel(message, cb) {
 }
 
 controller.on('rtm_open', function(bot) {
+  if (started_claim) return;
+  started_claim = true;
   console.log("Claiming instance lock in postgres (id " + instanceId + ")");
   controller.storage.instance.claim(instanceId, function(err, currentInstanceId) {
     if (err) {


### PR DESCRIPTION
The rtm_open event can be sent on reconnection to slack.  I think this
has been causing the bot to attempt to claim the lock again each time,
and thus sending multiple messages to the slack channel.