### PR TITLE
Shut the process down on connection close

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -96,14 +96,14 @@ function start_rtm() {
   bot.startRTM(function(err,bot,payload) {
     if (err) {
       console.log('Failed to start RTM');
-      return setTimeout(start_rtm, 60000);
+      return setTimeout(shutDown, 60000);
     }
     console.log("RTM started!");
   });
 }
 
 controller.on('rtm_close', function(bot, err) {
-        start_rtm();
+  shutDown();
 });
 
 function shutDown() {


### PR DESCRIPTION
The slack bot previously had logic to retry starting the RTM connection
to Slack each time an error happened when starting it, or when an
rtm_close() message was received.  We've been seeing instances where the
slack bot sends multiple replies to messages, which I hypothesise is due
to multiple connections ending up open (perhaps the 'rtm_close' event
can be sent for a non-permanent close?  Or perhaps an error can be
returned by startRTM but the connection still be formed?)

This patch attempts to address that by shutting down the whole process
on rtm_close(), or on an error with startRTM.  In the case of an error,
a delay of 60 seconds is added to avoid a busy loop if slack is down for
a period of time.