### PR TITLE
Move bots output to a special output channel

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -115,7 +115,7 @@ function reportInBotsChannel(message, cb) {
   return request.post({
     url: `https://${slackDomain}.slack.com/api/chat.postMessage`,
     form: {
-      channel: '#bots',
+      channel: '#bots-output',
       token: process.env.apitoken,
       username: bot.identity.name,
       icon_url:  "https://avatars.slack-edge.com/2017-06-12/196465304149_07a2c870e7ee855d6413_48.png",


### PR DESCRIPTION
The bot output should go to a special channel, as #bots is supposed to cover discussions about bots, rather than debug statements.