### PR TITLE
Timeout conversations after a while

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -478,5 +478,11 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
       }
     ], {}, 'default');
 
+    /* timeout the conversation after 2 minutes of inactivity */
+    convo.setTimeout(1000*120);
+    convo.onTimeout(function(convo) {
+      convo.say("You've been quiet for a while. I'm going to assume that you have what you need for now. Bye!");
+      convo.next();
+    });
   });
 });


### PR DESCRIPTION
A conversation is a state machine. To avoid a user (hi!) getting
confused about where they are, timeout the conversation after a
couple of minutes of inactivity.