### PR TITLE
add highways England

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -11,6 +11,7 @@ var approvedDomains = [
   'gov.scot',
   'gov.uk',
   'hee.nhs.uk',
+  'highwaysengland.co.uk',
   'hmcts.net',
   'hs2.org.uk',
   'marinemanagement.org.uk',


### PR DESCRIPTION
Added the domain for highways England to the whitelist: highwaysengland.co.uk
https://www.gov.uk/government/organisations/highways-england