### PR TITLE
Use wildcard versions for node and npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "uuid": "^3.1.0"
   },
   "engines": {
-    "node": "9.11.2",
-    "npm": "4.1.2"
+    "node": "9.x",
+    "npm": "4.x"
   },
   "author": "michael.brunton-spall@digital.cabinet-office.gov.uk",
   "license": "MIT",


### PR DESCRIPTION
This should make the application less brittle when PaaS drop support for
older node engines. Since the 9.x stream is not LTS this is still likely
to break soon - see the node [release schedule](https://github.com/nodejs/Release#release-schedule).

Using the 9.x syntax will pick the highest version starting with 9 - see
https://github.com/npm/node-semver#x-ranges-12x-1x-12- for full details.