### PR TITLE
Add biglotteryfund.org.uk to approved domains

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -3,6 +3,7 @@
 var approvedDomains = [
   'acas.org.uk',
   'bankofengland.co.uk',
+  'biglotteryfund.org.uk',
   'bl.uk',
   'bmtdsl.co.uk',
   'cqc.org.uk',


### PR DESCRIPTION
The Big Lottery Fund is a non-departmental public body sponsored by the Department for Digital, Culture, Media & Sport.