### PR TITLE
Add JNCC to approved domains

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -15,6 +15,7 @@ var approvedDomains = [
   'highwaysengland.co.uk',
   'hmcts.net',
   'hs2.org.uk',
+  'jncc.gov.uk',
   'marinemanagement.org.uk',
   'mod.uk',
   'naturalengland.org.uk',


### PR DESCRIPTION
Add domain for JNCC to the whilelist: jncc.gov.uk
https://www.gov.uk/government/organisations/joint-nature-conservation-committee