### PR TITLE
Update domains.js to add brighton-hove.gov.uk

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -6,6 +6,7 @@ var approvedDomains = [
   'biglotteryfund.org.uk',
   'bl.uk',
   'bmtdsl.co.uk',
+  'brighton-hove.gov.uk',
   'cqc.org.uk',
   'ddc-mod.org',
   'digital.nhs.uk',


### PR DESCRIPTION
Added Brighton and Hove City Council to list of approved domains.