### PR TITLE
add food.gov.uk domain to the slackbot

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -10,6 +10,7 @@ var approvedDomains = [
   'ddc-mod.org',
   'digital.nhs.uk',
   'electoralcommission.org.uk',
+  'food.gov.uk',
   'gov.scot',
   'gov.uk',
   'hee.nhs.uk',


### PR DESCRIPTION
Hi all, can you please add food.gov.uk to the slackbot (new food standards agency domain).