### PR TITLE
Adds engineering.digital.dwp.gov.uk to domains

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -10,6 +10,7 @@ var approvedDomains = [
   'ddc-mod.org',
   'digital.nhs.uk',
   'electoralcommission.org.uk',
+  'engineering.digital.dwp.gov.uk',
   'gov.scot',
   'gov.uk',
   'hee.nhs.uk',


### PR DESCRIPTION
Please add this domain for x-gov Slack access