### PR TITLE
Add the judiciary.uk to list of domains

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -10,6 +10,7 @@ var approvedDomains = [
   'gov.uk',
   'gov.scot',
   'acas.org.uk',
+  'awe.co.uk',
   'bankofengland.co.uk',
   'biglotteryfund.org.uk',
   'bl.uk',


### PR DESCRIPTION
Hello! Could you please add judiciary.uk to the list of domains? We are a new Digital Service team working in the Judicial Office of RCJ and would love to be able to join the channel.
Many thanks
Havina Georgieva
Associate Product Manager