### PR TITLE
Update domains.js

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -41,6 +41,7 @@ var approvedDomains = [
   'sepa.org.uk',
   'slc.co.uk',
   'stfc.ac.uk',
+  'tnlcommunityfund.org.uk',
   'wiltonpark.org.uk',
   'ukri.org'
 ]


### PR DESCRIPTION
Adding tnlcommunityfund.org.uk - new domain for Big Lottery Fund users.