### PR TITLE
Teach the bot about the weather

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -516,16 +516,11 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
   });
 });
 
-const weatherSlashCommand = (bot, raw_message) => {
-
-}
-
-controller.on('slash_command', (bot, message) => {
-  const slack_message = message.raw_message;
-  switch(slack_message.command) {
-    case "weather":
-      weatherSlashCommand(bot, raw_message);
-      break;
-
-  }
+controller.hears(['weather', 'wx'], 'direct_mention,direct_message', (bot, message) => {
+  bot.replyInThread(message, "Checkin' the weather for you now 🌞");
+  const heard_word = message.text.split(" ")[1];
+  const location = message.text.split(heard_word)[1];
+  request.get({url: 'https://slack-wdh-gaz.glitch.me/weather?location=' + location, json: true }, (error, response, body) => {
+    bot.reply(message, body);
+  })
 })

--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -524,6 +524,7 @@ controller.hears(['weather', 'wx'], 'direct_mention,direct_message', (bot, messa
    * The Glitch app is written by Jake Hendy (@JakeHendy) and accesses the Met Office Weather DataHub, as well as
    * its own internal, semi-public Gazetteer. 
    * The GlitchApp returns an object containing a `blocks` property, which is fed straight through as the response.
+   * https://api.slack.com/tools/block-kit-builder is a good tool to build block kits. 
    */
   request.get({url: 'https://slack-wdh-gaz.glitch.me/weather?location=' + location, json: true }, (error, response, body) => {
     bot.reply(message, body);

--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -455,7 +455,7 @@ controller.hears(["^welcome"], 'direct_mention,direct_message', function(bot, me
 
 controller.hears(["^help","^commands"], "direct_message", function(bot, message) {
   bot.startConversation(message, function(err,convo) {
-    TOPICS="I can tell you about:\nwelcome\ninvites\nannouncements\nroles\nWhich would you like to know more about? (say done when you are finished)";
+    TOPICS="I can tell you about:\nwelcome\ninvites\nannouncements\nroles\nweather\nWhich would you like to know more about? (say done when you are finished)";
     convo.addQuestion(TOPICS, [
       {
         pattern: 'welcome',
@@ -492,6 +492,13 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
         }
       },
       {
+        pattern: "weather?",
+        callback: function(response, convo) {
+          convo.say("Asking for the weather will get you a forecast from the Met Office. Example: @${bot.identity.name} weather Exeter or @${bot.identity.name} wx Edinburgh.\nFeedback is always appreciated, give @Jake Hendy a heads up.");
+          convo.next();
+        }
+      },
+      {
         pattern: "done",
         callback: function(response, convo) {
           convo.say("Ok, I hope I was helpful");
@@ -516,7 +523,7 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
   });
 });
 
-controller.hears(['weather', 'wx'], 'direct_mention,direct_message', (bot, message) => {
+controller.hears(['weather', 'wx'], 'ambient,direct_mention,direct_message', (bot, message) => {
   bot.replyInThread(message, "Checkin' the weather for you now 🌞");
   const heard_word = message.text.split(" ")[1];
   const location = message.text.split(heard_word)[1];

--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -520,6 +520,11 @@ controller.hears(['weather', 'wx'], 'direct_mention,direct_message', (bot, messa
   bot.replyInThread(message, "Checkin' the weather for you now 🌞");
   const heard_word = message.text.split(" ")[1];
   const location = message.text.split(heard_word)[1];
+  /**
+   * The Glitch app is written by Jake Hendy (@JakeHendy) and accesses the Met Office Weather DataHub, as well as
+   * its own internal, semi-public Gazetteer. 
+   * The GlitchApp returns an object containing a `blocks` property, which is fed straight through as the response.
+   */
   request.get({url: 'https://slack-wdh-gaz.glitch.me/weather?location=' + location, json: true }, (error, response, body) => {
     bot.reply(message, body);
   })

--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -525,7 +525,16 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
 
 controller.hears(['weather', 'wx'], 'ambient,direct_mention,direct_message', (bot, message) => {
   bot.replyInThread(message, "Checkin' the weather for you now 🌞");
+  /** 
+  message.text == <@botID> weather location
+  message.text.split(" ") == ["<@botID", "weather", "location_part1", "location_part2"]
+  Which utterance got us here?             ^^^ this one, so split on that word
+  */
   const heard_word = message.text.split(" ")[1];
+  /**
+   * message.text == <@botID> weather location
+   * message.text.split("weather") == ["<@botID>", "location"]
+   */
   const location = message.text.split(heard_word)[1];
   /**
    * The Glitch app is written by Jake Hendy (@JakeHendy) and accesses the Met Office Weather DataHub, as well as
@@ -534,6 +543,20 @@ controller.hears(['weather', 'wx'], 'ambient,direct_mention,direct_message', (bo
    * https://api.slack.com/tools/block-kit-builder is a good tool to build block kits. 
    */
   request.get({url: 'https://slack-wdh-gaz.glitch.me/weather?location=' + location, json: true }, (error, response, body) => {
-    bot.reply(message, body);
+    if(response.statusCode !== 200) {
+      let content = [
+        {
+          "type": "section",
+          "text": {
+            "type": "plain_text",
+            "text": "It seems we're unable to get a result for you 😢 try again later or ping @Jake Hendy",
+            "emoji": true
+          }
+        }
+      ]
+      bot.reply(message, content)
+    } else {
+      bot.reply(message, body);
+    }
   })
 })

--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -515,3 +515,17 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
     });
   });
 });
+
+const weatherSlashCommand = (bot, raw_message) => {
+
+}
+
+controller.on('slash_command', (bot, message) => {
+  const slack_message = message.raw_message;
+  switch(slack_message.command) {
+    case "weather":
+      weatherSlashCommand(bot, raw_message);
+      break;
+
+  }
+})

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_ENV=test nodejs ./index.js"
   },
   "dependencies": {
-    "botkit": "^0.6.14",
+    "botkit": "^0.7.0",
     "cfenv": "^1.0.4",
     "pg": "^6.1.5",
     "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_ENV=test nodejs ./index.js"
   },
   "dependencies": {
-    "botkit": "^0.7.0",
+    "botkit": "^0.7.4",
     "cfenv": "^1.0.4",
     "pg": "^6.1.5",
     "request": "^2.88.0",


### PR DESCRIPTION
The bot knows about the weather, and its clientele can now ask it the weather by:
`@botname weather [location]` or `@botname wx [location]` 

The bot passes this off to a private app hosted on Glitch created by myself. This app uses [Met Office Weather DataHub](https://metoffice.apiconnect.ibmcloud.com/metoffice/production) and a semi-private Met Office Gazetteer to build a response. The response from the Glitch App conforms to the Slack Blocks specification, so is passed straight through to the `bot.reply(message, json)` method.

TODO:
- [x] Add help text for weather/wx command
- [x] Handle negative responses from Glitch app
- [x] Add ambient mentions