### PR TITLE
Add Judicial Appointments Commission to domains.js

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -26,6 +26,7 @@ var approvedDomains = [
   'hmcts.net',
   'hs2.org.uk',
   'jncc.gov.uk',
+  'judicialappointments.digital',
   'marinemanagement.org.uk',
   'mod.uk',
   'naturalengland.org.uk',


### PR DESCRIPTION
I've added `judicialappointments.digital` to the allowed domains list in `domains.js`. This is the domain name used by members of the Judicial Appointments Commission's Digital team.