### PR TITLE
Updates weather response to reuse a single message

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -524,39 +524,32 @@ controller.hears(["^help","^commands"], "direct_message", function(bot, message)
 });
 
 controller.hears(['weather', 'wx'], 'direct_mention,direct_message', (bot, message) => {
-  bot.replyInThread(message, "Checkin' the weather for you now 🌞");
-  /** 
-  message.text == <@botID> weather location
-  message.text.split(" ") == ["<@botID", "weather", "location_part1", "location_part2"]
-  Which utterance got us here?             ^^^ this one, so split on that word
-  */
-  const heard_word = message.text.split(" ")[1];
-  /**
-   * message.text == <@botID> weather location
-   * message.text.split("weather") == ["<@botID>", "location"]
-   */
-  const location = message.text.split(heard_word)[1];
-  /**
-   * The Glitch app is written by Jake Hendy (@JakeHendy) and accesses the Met Office Weather DataHub, as well as
-   * its own internal, semi-public Gazetteer. 
-   * The GlitchApp returns an object containing a `blocks` property, which is fed straight through as the response.
-   * https://api.slack.com/tools/block-kit-builder is a good tool to build block kits. 
-   */
-  request.get({url: 'https://slack-wdh-gaz.glitch.me/weather?location=' + location, json: true }, (error, response, body) => {
-    if(response.statusCode !== 200) {
-      let content = [
-        {
-          "type": "section",
-          "text": {
-            "type": "plain_text",
-            "text": "It seems we're unable to get a result for you 😢 try again later or ping @Jake Hendy",
-            "emoji": true
-          }
-        }
-      ]
-      bot.reply(message, content)
-    } else {
-      bot.reply(message, body);
-    }
-  })
+  bot.replyAndUpdate(message, "Checkin' the weather for you now 🌞", (err, src, updateResponse) => {
+    /**
+    message.text == <@botID> weather location
+    message.text.split(" ") == ["<@botID", "weather", "location_part1", "location_part2"]
+    Which utterance got us here?             ^^^ this one, so split on that word
+    */
+    const heard_word = message.text.split(" ")[1];
+    /**
+     * message.text == <@botID> weather location
+     * message.text.split("weather") == ["<@botID>", "location"]
+     */
+    const location = message.text.split(heard_word)[1];
+    /**
+     * The Glitch app is written by Jake Hendy (@JakeHendy) and accesses the Met Office Weather DataHub, as well as
+     * its own internal, semi-public Gazetteer.
+     * The GlitchApp returns an object containing a `blocks` property, which is fed straight through as the response.
+     * https://api.slack.com/tools/block-kit-builder is a good tool to build block kits.
+     */
+    request.get({url: 'https://slack-wdh-gaz.glitch.me/weather?location=' + location, json: true }, (error, response, body) => {
+      if(response.statusCode !== 200) {
+        updateResponse("It seems we\'re unable to get a result for you 😢\nIs it definitely in the UK?\nTry again later or ping @Jake Hendy");
+        // bot.reply(message, content)
+      } else {
+        // bot.reply(message, body);
+        updateResponse(body);
+      }
+    })
+  });
 })


### PR DESCRIPTION
It will now edit the placeholder message when a weather response is received to save on the message spam.
Also fixes the error response, which will now reliably trigger if the weather API call times out.