### PR TITLE
Add Scottish Natural Heritage's domain

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -30,6 +30,7 @@ var approvedDomains = [
   'marinemanagement.org.uk',
   'mod.uk',
   'naturalengland.org.uk',
+  'nature.scot',
   'nhs.net',
   'nhsbt.nhs.uk',
   'nhsx.nhs.uk',


### PR DESCRIPTION
We previously had email addresses on the `snh.gov.uk` domain, but we've recently changed to `nature.scot` and I'd like to invite the rest of my team.