### PR TITLE
Adding hes.scot domain to the allow list.

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -21,6 +21,7 @@ var approvedDomains = [
   'digital.nhs.uk',
   'electoralcommission.org.uk',
   'hee.nhs.uk',
+  'hes.scot',
   'highwaysengland.co.uk',
   'hlf.org.uk',
   'hmcts.net',


### PR DESCRIPTION
This domain is of a Scottish Government public body.