### PR TITLE
Adding homesengland.gov.uk to the allow list

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -25,6 +25,7 @@ var approvedDomains = [
   'highwaysengland.co.uk',
   'hlf.org.uk',
   'hmcts.net',
+  'homesengland.gov.uk',
   'hs2.org.uk',
   'jncc.gov.uk',
   'judicialappointments.digital',


### PR DESCRIPTION
Adding the domain of [Homes England](https://www.gov.uk/government/organisations/homes-england).