### PR TITLE
Added heritagefund.org.uk to approvedDomains list

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -21,6 +21,7 @@ var approvedDomains = [
   'digital.nhs.uk',
   'electoralcommission.org.uk',
   'hee.nhs.uk',
+  'heritagefund.org.uk',
   'hes.scot',
   'highwaysengland.co.uk',
   'hlf.org.uk',


### PR DESCRIPTION
The National Lottery Heritage Fund is an arms-length body of the Department for Digital, Culture, Media and Sport.