### PR TITLE
Remove the invite functionality

### DIFF
--- a/app/slack_bot.js
+++ b/app/slack_bot.js
@@ -274,13 +274,13 @@ controller.hears(['^invite.*\\|(.*)>'], 'direct_message', function(bot, message)
     var email = message.match[1];
     controller.log("Got an invite for email: "+email);
     bot.reply(`I'm afraid that I can no longer invite people.  Instead type /invite_people $email and that will invite them`);
-}
+});
 
 controller.hears(['^invite.*\\|(.*)>'], 'direct_mention', function(bot, message) {
     var email = message.match[1];
     controller.log("Got an invite for email: "+email);
     bot.replyInThread(`I'm afraid that I can no longer invite people.  Instead type /invite_people $email and that will invite them`);
-}
+});
 
 controller.hears(['^uptime$', '^identify yourself$', '^who are you$', '^what is your name$'],
     'direct_message,direct_mention,mention', function(bot, message) {


### PR DESCRIPTION
Because of changes to the Slack API, the bot is no longer able to invite people.

Slack made the API calls for inviting people only usable by the enterprise grid system. We don't have that, so remove the existing invite functionality and instead point people to the built in slash command