### PR TITLE
Add engineering.digital.dwp.gov.uk

### DIFF
--- a/app/domains.js
+++ b/app/domains.js
@@ -53,7 +53,8 @@ var approvedDomains = [
   'transportforthenorth.com',
   'wiltonpark.org.uk',
   'wmca.org.uk',
-  'ukri.org'
+  'ukri.org',
+  'engineering.digital.dwp.gov.uk'
 ]
 
 function hasApprovedEmail(email) {


### PR DESCRIPTION
engineering.digital.dwp.gov.uk is used by Engineering staff in DWP